### PR TITLE
Created a `calculate` function with respective test case

### DIFF
--- a/__test__/calculate.test.tsx
+++ b/__test__/calculate.test.tsx
@@ -23,4 +23,10 @@ describe("calculate function", () => {
     const result = calculate(longInput);
     expect(result).toBe(expectedSum);
   });
+  test("calcualte returns the correct sum for newline and comma-reprated numbers", () => {
+    const result1 = calculate("1\n2,3");
+    const result2 = calculate("1\n3,6\n6,2\n7");
+    expect(result1).toBe(6);
+    expect(result2).toBe(25);
+  });
 });

--- a/__test__/calculate.test.tsx
+++ b/__test__/calculate.test.tsx
@@ -1,0 +1,8 @@
+import { calculate } from "../app/_utils/Caluclate";
+
+describe("calculate function", () => {
+  test("returns 0 when inputValue is empty", () => {
+    const result = calculate("");
+    expect(result).toBe(0);
+  });
+});

--- a/__test__/calculate.test.tsx
+++ b/__test__/calculate.test.tsx
@@ -1,8 +1,26 @@
 import { calculate } from "../app/_utils/Caluclate";
+const generateLongString = (numValues: number): string => {
+  const values = Array.from({ length: numValues }, (_, index) => index + 1);
+  return values.join(",");
+};
 
 describe("calculate function", () => {
   test("returns 0 when inputValue is empty", () => {
     const result = calculate("");
     expect(result).toBe(0);
+  });
+  test("calculate returns the correct sum for comma-separated numbers", () => {
+    const result1 = calculate("1,2,3");
+    const result2 = calculate("9,5,3,20");
+    const result3 = calculate("0,0,0,2");
+    expect(result1).toBe(6); // Expected sum of 1 + 2 + 3
+    expect(result2).toBe(37); // Expected sum of 9 + 5 + 3 + 20
+    expect(result3).toBe(2); // Expected sum of 0 + 0 + 0 + 2
+  });
+  test("calculate returns the correct sum for a long comma-separated string", () => {
+    const longInput = generateLongString(10000); // Generate a string with 10,000 values
+    const expectedSum = (10000 * (10000 + 1)) / 2; // Sum of first 10,000 natural numbers (n* (n+1))/2
+    const result = calculate(longInput);
+    expect(result).toBe(expectedSum);
   });
 });

--- a/__test__/calculator.test.tsx
+++ b/__test__/calculator.test.tsx
@@ -40,4 +40,19 @@ describe("Calculator", () => {
     fireEvent.click(closeButton);
     expect(dialog).not.toBeInTheDocument();
   });
+  it("handleCalculate sets result to 0 when inputValue is empty", () => {
+    render(<Calculator isSidebarOpen={false} />);
+
+    const textarea = screen.getByPlaceholderText(
+      "Enter the String to calculate the sum."
+    );
+    fireEvent.change(textarea, { target: { value: "" } });
+
+    const calculateButton = screen.getByText("Calculate");
+    fireEvent.click(calculateButton);
+
+    const resultElement = screen.getByTestId("result");
+    expect(resultElement).toBeInTheDocument();
+    expect(resultElement.textContent).toBe("Result: 0");
+  });
 });

--- a/__test__/navbar.test.tsx
+++ b/__test__/navbar.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Navbar from "../app/_components/Navbar";
 
 import { render, screen, fireEvent } from "@testing-library/react";
+import Calculator from "@/app/_components/Calculator";
 
 describe("Navbar", () => {
   it("should contain the application name", () => {

--- a/app/_components/calculator.tsx
+++ b/app/_components/calculator.tsx
@@ -4,11 +4,15 @@ import React, { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import SampleInputDialog from "./SampleInputdialog";
+import { calculate } from "../_utils/Caluclate";
 
 const Calculator: React.FC<{ isSidebarOpen: boolean }> = ({
   isSidebarOpen,
 }) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const [result, setResult] = useState<number | undefined>(0);
+  const [isResult, setIsResult] = useState(false);
 
   const handleOpenDialog = () => {
     setIsDialogOpen(true);
@@ -16,6 +20,11 @@ const Calculator: React.FC<{ isSidebarOpen: boolean }> = ({
 
   const handleCloseDialog = () => {
     setIsDialogOpen(false);
+  };
+
+  const handleCalculate = () => {
+    setIsResult(true);
+    setResult(calculate(inputValue));
   };
 
   return (
@@ -39,11 +48,16 @@ const Calculator: React.FC<{ isSidebarOpen: boolean }> = ({
         <textarea
           className="w-full h-40 p-4 text-lg border border-gray-300 rounded"
           placeholder="Enter the String to calculate the sum."
+          onChange={(e) => setInputValue(e.target.value)}
         ></textarea>
       </div>
-      <button className="px-4 py-2 mt-4 text-lg font-semibold text-white bg-blue-950 rounded hover:bg-blue-1000">
+      <button
+        className="px-4 py-2 mt-4 text-lg font-semibold text-white bg-blue-950 rounded hover:bg-blue-1000"
+        onClick={handleCalculate}
+      >
         Calculate
       </button>
+      {isResult && <p data-testid="result">Result: {result}</p>}
       <SampleInputDialog isOpen={isDialogOpen} onClose={handleCloseDialog} />
     </div>
   );

--- a/app/_utils/Caluclate.tsx
+++ b/app/_utils/Caluclate.tsx
@@ -1,3 +1,9 @@
 export const calculate = (inputValue: string): number | undefined => {
   if (inputValue === "") return 0;
+  const numbers = inputValue
+    .split(",")
+    .map((numStr) => parseInt(numStr.trim(), 10));
+  const sum = numbers.reduce((acc, num) => acc + num, 0);
+
+  return sum;
 };

--- a/app/_utils/Caluclate.tsx
+++ b/app/_utils/Caluclate.tsx
@@ -1,8 +1,14 @@
 export const calculate = (inputValue: string): number | undefined => {
   if (inputValue === "") return 0;
-  const numbers = inputValue
+  // Normalize input: replace newlines with commas
+  const normalizedInput = inputValue.replace(/\n/g, ",");
+
+  // Split the normalized input string by commas, trim each segment, then parse into integers
+  const numbers = normalizedInput
     .split(",")
     .map((numStr) => parseInt(numStr.trim(), 10));
+
+  // Calculate the sum of the parsed numbers
   const sum = numbers.reduce((acc, num) => acc + num, 0);
 
   return sum;

--- a/app/_utils/Caluclate.tsx
+++ b/app/_utils/Caluclate.tsx
@@ -1,0 +1,3 @@
+export const calculate = (inputValue: string): number | undefined => {
+  if (inputValue === "") return 0;
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest",
+    "test": "jest --coverage",
     "test:watch": "jest --watchAll"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request includes the following features in the `calculate` function:
-  Input: a string of comma-separated numbers
 - Output: an integer, sum of the numbers
- Examples:
   - Input: “”, Output: 0
   - Input: “1”, Output: 1
   - Input: “1,5”, Output: 6
 -  Capable of handling any amount of numbers.
 -  Handles new lines between numbers instead of commas. ("1\n2,3" should return 6)