### PR TITLE
Enhanced `calculate` function to support different delimiters

### DIFF
--- a/__test__/calculate.test.tsx
+++ b/__test__/calculate.test.tsx
@@ -29,4 +29,10 @@ describe("calculate function", () => {
     expect(result1).toBe(6);
     expect(result2).toBe(25);
   });
+  test("calculate returns the correct sum with support for different delimiters", () => {
+    const result1 = calculate("//;\n1;2");
+    expect(result1).toBe(3);
+    const result2 = calculate("//;\n1\n2;6\n7;4");
+    expect(result2).toBe(20);
+  });
 });

--- a/app/_utils/Caluclate.tsx
+++ b/app/_utils/Caluclate.tsx
@@ -1,11 +1,26 @@
 export const calculate = (inputValue: string): number | undefined => {
   if (inputValue === "") return 0;
+
+  let delimiter = ","; // Default delimiter
+  let numbersString = inputValue;
+
+  // Check if the input starts with a custom delimiter definition
+  if (inputValue.startsWith("//")) {
+    // Extract delimiter from the input
+    const delimiterMatch = inputValue.match(/^\/\/(.*)\n/);
+    if (delimiterMatch && delimiterMatch[1]) {
+      delimiter = delimiterMatch[1];
+      // Remove the delimiter definition from the input string
+      numbersString = inputValue.substring(delimiterMatch[0].length);
+    }
+  }
+
   // Normalize input: replace newlines with commas
-  const normalizedInput = inputValue.replace(/\n/g, ",");
+  const normalizedInput = numbersString.replace(/\n/g, delimiter);
 
   // Split the normalized input string by commas, trim each segment, then parse into integers
   const numbers = normalizedInput
-    .split(",")
+    .split(delimiter)
     .map((numStr) => parseInt(numStr.trim(), 10));
 
   // Calculate the sum of the parsed numbers


### PR DESCRIPTION
Enabled Support different delimiters:
- To change the delimiter, the beginning of the string will contain a separate line that looks like this: "//[delimiter]\n[numbers…]". For example, "//;\n1;2" where the delimiter is ";" should return 3