### PR TITLE
Improved the `calculate` function to throw an error if negative numbers are provided

### DIFF
--- a/__test__/calculate.test.tsx
+++ b/__test__/calculate.test.tsx
@@ -35,4 +35,15 @@ describe("calculate function", () => {
     const result2 = calculate("//;\n1\n2;6\n7;4");
     expect(result2).toBe(20);
   });
+  it("throws an error for negative numbers", () => {
+    const input = "//;\n1;-2;3";
+    expect(() => calculate(input)).toThrow("Negative numbers not allowed: -2");
+  });
+
+  it("throws an error for multiple negative numbers", () => {
+    const input = "//;\n1;-2;-3;4;-5";
+    expect(() => calculate(input)).toThrow(
+      "Negative numbers not allowed: -2, -3, -5"
+    );
+  });
 });

--- a/__test__/navbar.test.tsx
+++ b/__test__/navbar.test.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import Navbar from "../app/_components/Navbar";
 
-import { render, screen, fireEvent } from "@testing-library/react";
-import Calculator from "@/app/_components/Calculator";
+import { render, screen } from "@testing-library/react";
 
 describe("Navbar", () => {
   it("should contain the application name", () => {

--- a/app/_components/calculator.tsx
+++ b/app/_components/calculator.tsx
@@ -13,6 +13,8 @@ const Calculator: React.FC<{ isSidebarOpen: boolean }> = ({
   const [inputValue, setInputValue] = useState("");
   const [result, setResult] = useState<number | undefined>(0);
   const [isResult, setIsResult] = useState(false);
+  const [error, setError] = useState("");
+  const [isError, setIsError] = useState(false);
 
   const handleOpenDialog = () => {
     setIsDialogOpen(true);
@@ -23,8 +25,21 @@ const Calculator: React.FC<{ isSidebarOpen: boolean }> = ({
   };
 
   const handleCalculate = () => {
-    setIsResult(true);
-    setResult(calculate(inputValue));
+    setIsResult(false);
+    setIsError(false);
+    try {
+      setIsResult(true);
+      setResult(calculate(inputValue));
+    } catch (error: any) {
+      if (error instanceof Error) {
+        setIsError(true);
+        setError(error.message);
+      } else {
+        setIsError(true);
+        setError("An unknown error occurred");
+        console.error("An unknown error occurred:", error);
+      }
+    }
   };
 
   return (
@@ -48,7 +63,11 @@ const Calculator: React.FC<{ isSidebarOpen: boolean }> = ({
         <textarea
           className="w-full h-40 p-4 text-lg border border-gray-300 rounded"
           placeholder="Enter the String to calculate the sum."
-          onChange={(e) => setInputValue(e.target.value)}
+          onChange={(e) => {
+            setIsError(false)
+            setIsResult(false)
+            setInputValue(e.target.value)
+          }}
         ></textarea>
       </div>
       <button
@@ -58,6 +77,11 @@ const Calculator: React.FC<{ isSidebarOpen: boolean }> = ({
         Calculate
       </button>
       {isResult && <p data-testid="result">Result: {result}</p>}
+      {isError && (
+        <p className="text-red-400 " data-testid="error">
+          Error: {error}
+        </p>
+      )}
       <SampleInputDialog isOpen={isDialogOpen} onClose={handleCloseDialog} />
     </div>
   );

--- a/app/_utils/Caluclate.tsx
+++ b/app/_utils/Caluclate.tsx
@@ -23,6 +23,13 @@ export const calculate = (inputValue: string): number | undefined => {
     .split(delimiter)
     .map((numStr) => parseInt(numStr.trim(), 10));
 
+  // Check for negative numbers
+  const negativeNumbers = numbers.filter((num) => num < 0);
+  if (negativeNumbers.length > 0) {
+    const negativeNumbersList = negativeNumbers.join(", ");
+    throw new Error(`Negative numbers not allowed: ${negativeNumbersList}`);
+  }
+
   // Calculate the sum of the parsed numbers
   const sum = numbers.reduce((acc, num) => acc + num, 0);
 


### PR DESCRIPTION
The `calculate` function now handles negative numbers and throws an exception with the message 'negative numbers not allowed <negative_number>'. If multiple negative numbers are present, they are shown in the exception message separated by commas.